### PR TITLE
temp: make all openedx repos phony for now

### DIFF
--- a/repos_openedx.tf
+++ b/repos_openedx.tf
@@ -8,74 +8,89 @@
 module "repo_build_test_release_wg" {
   source = "./modules/repo"
   name   = "build-test-release-wg"
+  phony = true
 }
 
 module "repo_community_wg" {
   source = "./modules/repo"
   name   = "community-wg"
+  phony = true
 }
 
 module "repo_data_wg" {
   source = "./modules/repo"
   name   = "data-wg"
+  phony = true
 }
 
 module "repo_frontend_wg" {
   source = "./modules/repo"
   name   = "frontend-wg"
+  phony = true
 }
 
 module "repo_metrics_dashboard" {
   source = "./modules/repo"
   name   = "metrics-dashboard"
+  phony = true
 }
 
 module "repo_olxcleaner" {
   source = "./modules/repo"
   name   = "olxcleaner"
+  phony = true
 }
 
 module "repo_onboarding_course_introduction" {
   source = "./modules/repo"
   name   = "onboarding-course-introduction"
+  phony = true
 }
 
 module "repo_openedx_conference_website" {
   source = "./modules/repo"
   name   = "openedx-conference-website"
+  phony = true
 }
 
 module "repo_openedx_i18n" {
   source = "./modules/repo"
   name   = "openedx-i18n"
+  phony = true
 }
 
 module "repo_openedx_slack_invite" {
   source = "./modules/repo"
   name   = "openedx-slack-invite"
+  phony = true
 }
 
 module "repo_openedx_tech_radar" {
   source = "./modules/repo"
   name   = "openedx-tech-radar"
+  phony = true
 }
 
 module "repo_platform_roadmap" {
   source = "./modules/repo"
   name   = "platform-roadmap"
+  phony = true
 }
 
 module "repo_pr_watcher_notifier" {
   source = "./modules/repo"
   name   = "pr_watcher_notifier"
+  phony = true
 }
 
 module "repo_public_engineering" {
   source = "./modules/repo"
   name   = "public-engineering"
+  phony = true
 }
 
 module "repo_terraform_github" {
   source = "./modules/repo"
   name   = "terraform-github"
+  phony = true
 }


### PR DESCRIPTION
`terraform apply` is failing on main because we need to
import the `openedx` repos into terraform state.

We'd rather try this out on a smaller set of repos
(the "Phase 0" repos), so for now, just mark the `openedx`
org repos as phony.