### PR TITLE
Add Team Permissions During Repo Migration

### DIFF
--- a/migrate/export-test.json
+++ b/migrate/export-test.json
@@ -1,0 +1,21 @@
+{
+    "export_date_utc": "2021-11-30T17:10:15.544743",
+    "repos": [
+        {
+            "name": "transfer_test_repo",
+            "user_access": {},
+            "team_access": {
+                "edx-admin": 4,
+                "community-engineering": 4,
+                "push-pull-all": 2
+            }
+        },
+        {
+            "name": "transfer_test_repo_2",
+            "user_access": {},
+            "team_access": {
+                "community-engineering": 4
+            }
+        }
+    ]
+}

--- a/migrate/migrate_repos.py
+++ b/migrate/migrate_repos.py
@@ -199,7 +199,7 @@ class RepoPermissions:
     Permissions for a particular repository.
     """
 
-    slug: str
+    slug: str              # Name of the repo
     teams: Dict[str, str]  # Mapping of team slug to permission slug
     users: Dict[str, str]  # Mapping of username to permission slug
 
@@ -349,7 +349,7 @@ def set_repo_permissions(permissions, api, dest_org, preview):
             click.echo(f" {team_slug}", nl=False)
             if not preview:
                 api.teams.add_or_update_repo_permissions_in_org(
-                    dest_org, team_slug, owner, permissions.slug
+                    dest_org, team_slug, owner, permissions.slug, access
                 )
         click.echo()
 

--- a/migrate/migrate_repos.py
+++ b/migrate/migrate_repos.py
@@ -349,7 +349,11 @@ def set_repo_permissions(permissions, api, dest_org, preview):
             click.echo(f" {team_slug}", nl=False)
             if not preview:
                 api.teams.add_or_update_repo_permissions_in_org(
-                    dest_org, team_slug, owner, permissions.slug, access
+                    org=dest_org,
+                    team_slug=team_slug,
+                    owner=owner,
+                    repo=permissions.slug,
+                    permission=access,
                 )
         click.echo()
 

--- a/migrate/migrate_repos.py
+++ b/migrate/migrate_repos.py
@@ -266,7 +266,7 @@ def load_permissions(teams_file, api, dest_org):
     known_usernames = {
         user['login']
         for user in itertools.chain.from_iterable(
-            paged(api.users.list, dest_org, per_page=100)
+            paged(api.orgs.list_members, dest_org, per_page=100)
         )
     }
     click.echo(f"-> Found {len(known_usernames)} usernames.")

--- a/migrate/migrate_repos.py
+++ b/migrate/migrate_repos.py
@@ -235,23 +235,9 @@ def load_permissions(teams_file, api, dest_org, skip_missing_teams):
     """
     Return a dict mapping of team_slug to RepoPermissions.
 
-    The GitHub API has two options for permissions:
-
-    Bulk permissions for multiple users/teams at a time, but no control over the
-    type of permission (just the common case: push):
-        https://docs.github.com/en/rest/reference/repos#set-team-access-restrictions
-        https://docs.github.com/en/rest/reference/repos#set-user-access-restrictions
-
-    More fine grained access that sets permissions for a single team/user + repo
-    at a time:
-        https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions
-        https://docs.github.com/en/rest/reference/teams#add-or-update-user-repository-permissions
-
-    So the strategy is going to be:
-
-    1. Move repo
-    2. Set bulk permissions for teams and users that are "push"
-    3. Set individual permission for teams/users that have other levels of permissions.
+    These include the team permissions we're planning to apply. If
+    skip_missing_teams is True, we'll strip out all missing teams and users
+    from the returned dictionary.
     """
     click.echo(f"Fetching known teams from {dest_org}...")
     known_team_slugs = {

--- a/migrate/migrate_repos.py
+++ b/migrate/migrate_repos.py
@@ -178,14 +178,14 @@ def migrate(
     for (i, repo) in enumerate(repos_to_transfer, start=1):
         click.secho(f"{i:>3}: {repo}", bold=True)
         if not preview:
-            # Transfer and add teams that have default push/pull permissions
-            # (other permissions require a separate call).
+            # Do the actual repo transfer call.
             api.repos.transfer(src_org, repo, dest_org)
 
-            # Without this sleep, I'd sometimes hit a race condition where the
+            # Without this sleep, we'll sometimes hit a race condition where the
             # repo would not have been recognized as transferred before the
             # permissions code tried to run, leading to errors because the repo
-            # did not exist at the new location yet.
+            # did not exist at the new location yet. Need to put something more
+            # robust here (auto-retry?) later.
             time.sleep(2)
 
         if repos_to_permissions:

--- a/migrate/migrate_repos.py
+++ b/migrate/migrate_repos.py
@@ -237,7 +237,7 @@ def load_permissions(teams_file, api, dest_org, skip_missing_teams):
 
     These include the team permissions we're planning to apply. If
     skip_missing_teams is True, we'll strip out all missing teams and users
-    from the returned dictionary.
+    from the returned RepoPermissions objects.
     """
     click.echo(f"Fetching known teams from {dest_org}...")
     known_team_slugs = {


### PR DESCRIPTION
Summary and soon-to-be-commit-message:

```
This adds support for assigning team permissions to repos that have
been transferred over. It makes the following changes to the
migrate_repos.py script:

* created option --permissions-file
* --skip-missing was changed to be --skip-missing-repos
* created option --skip-missing-teams
* --github-token can be used intead of the $GITHUB_TOKEN env var

The permissions file expects one of our export-{org}.json files. It
is optional because there are situations where we'll want to bring
over repos without team permissions (e.g. from edx-solutions). But
it is *strongly* recommended, so it will prompt the user for
confirmation if they don't specify one.

The script assumes that:

1. All teams with assigned repo permissions in the source org have
   matching counterparts in the destination org with the same slug.
   So if there's a "teaching-and-learning" team in the source org,
   there needs to be a matching "teaching-and-learning" team in the
   destination org.
2. All users with assigned repo permissions in the source org are
   also members of the destination org.

The script will create the team permissions in the new org to match
what they were in the old org.

If you specify a permissions file, all repos that are being
transferred must have entries in it. There is no way to bypass this
check–the script assumes that if entries are missing, it's because a
new repo was created recently and we don't have proper permissions
data for it in our export yet (and so we should redo the export).

This script does not explicitly create user permissions, since those
carry over automatically when doing the repo transfer. However we do
check to see if the users exist in the destination org, so that we
don't accidentally make a bunch of people outside collaborators without
meaning to.

By default, if any teams or users are missing from the destination org
the script will exit with an error. However there are situations where
we might want to skip missing teams. For instance, we're capturing
the admins of the "edx" org as a special team "edx-admin", so that we
can give them the appropriate access without making them admins of the
"openedx" org. This "edx-admin" team doesn't exist in the "edx" GitHub
org. So if we were to need to rollback and move repos back over to
edx from openedx, the script will complain that "edx-admin" is not a
team in the "edx" org. The --skip-missing-teams option was created to
address this case. It should just be used with caution.
```

Example run:

```
(gh-migration) daveormsbee@C02Z1CSWLVCG terraform-github % python migrate/migrate_repos.py --preview --permissions-file=migrate/export-edx.json --skip-missing-teams edx openedx migrate/phases/1-edx.txt
In Preview Mode: No changes will be made!
Read 4 repos from migrate/phases/1-edx.txt
Fetching the list of repos in source org edx...
Fetching known teams from openedx...
-> Found 265 teams.
Fetching known users from openedx...
-> Found 28 usernames.
Reading desired team and user permissions from migrate/export-edx.json...
Error: There are references to teams or users in migrate/export-edx.json that do not exist in destination org openedx:
Missing Users:
  DawoudSheraz used in edx-analytics-configuration
  Dillon-Dumesnil used in frontend-app-publisher
  PrecisionWordcraft used in edx-developer-docs
  Zacharis278 used in frontend-app-course-authoring
  albemarle used in frontend-app-support-tools
  awaisdar001 used in docs.edx.org
  carolguest used in edx-documentation
  doctoryes used in user-util
  edx-atlantis used in edx-notes-api
  edx-deployment used in credentials, credentials-themes, edx-platform
  edx-revenue-tasks used in ecommerce, ecommerce-scripts, ecommerce-worker, frontend-app-ecommerce, frontend-app-payment
  edx-status-bot used in edx-app-android
  edx-transifex-bot used in course-discovery, ecommerce, frontend-app-account, frontend-app-authn, frontend-app-course-authoring, frontend-app-ecommerce, frontend-app-learning, frontend-app-payment, frontend-app-profile, frontend-component-footer
  edx-travis used in TinCanPython, api-doc-tools, code-annotations, completion, crowdsourcehinter, cypress-e2e-tests, edx-analytics-exporter, edx-celeryutils, edx-cookiecutters, edx-developer-docs, edx-submissions, edx-toggles, edx-when, enterprise-catalog, eslint-config, frontend-app-account, frontend-app-authn, frontend-app-ecommerce, frontend-app-enterprise-public-catalog, frontend-app-gradebook, frontend-app-learner-portal-enterprise, frontend-app-learner-portal-programs, frontend-app-learning, frontend-app-payment, frontend-app-profile, frontend-app-program-console, frontend-app-publisher, frontend-build, frontend-component-cookie-policy-banner, frontend-component-header, frontend-enterprise, frontend-learner-portal-base, frontend-platform, license-manager, openedx-calc, registrar, taxonomy-connector, tinymce-language-selector, xblock-free-text-response, xblock-image-modal, xblock-in-video-quiz, xblock-qualtrics-survey, xblock-sql-grader, xblock-submit-and-compare, xss-utils
  iloveagent57 used in frontend-app-gradebook
  jmyatt used in frontend-app-publisher
  mikix used in frontend-app-publisher
  moconnell1453 used in taxonomy-connector
  mslotkeEDX used in acclaimbadge-xblock
  pactflow-github used in edx-val
  rgraber used in taxonomy-connector
  schenedx used in django-ratelimit-backend, edx-analytics-dashboard, edx-analytics-data-api, frontend-app-gradebook
  waheedahmed used in frontend-app-authn
Ignoring missing teams and users!

The following 4 repositories will be moved from edx to openedx: openedx-calc, frontend-app-support-tools, xqueue, edx-organizations

Proceed? [y/N]: y

Transferring 4 repositories from edx to openedx...
  1: openedx-calc
     assigning admin teams:
       arch-bom edx-admin
     assigning pull teams:
       pull-all
     assigning push teams:
       push-pull-all
  2: frontend-app-support-tools
     assigning admin teams:
       edx-admin
     assigning pull teams:
       pull-all
     assigning push teams:
       community-release-managers push-pull-all
  3: xqueue
     assigning admin teams:
       devops edx-admin edx-webhook-admin
     assigning pull teams:
       pull-all requires-io
     assigning push teams:
       arbi-bom community-release-managers edx-testeng-robot-rw push-pull-all sustaining-team xqueue-new-push
  4: edx-organizations
     assigning admin teams:
       edx-admin edx-webhook-admin
     assigning maintain teams:
       ccp-committer-idegtiarov
     assigning pull teams:
       pull-all testeng
     assigning push teams:
       arbi-bom arch-bom edx-testeng-robot-rw push-pull-all
```