### PR TITLE
Make sure the PM CC Triage Team has Triage Access to Public Repos

### DIFF
--- a/migrate/repo_checks.py
+++ b/migrate/repo_checks.py
@@ -77,8 +77,10 @@ class Check:
 
 class RequireTeamPermission(Check):
     """
-    A generic check that is not meant to be used directly
-    but is used to reduce some copy-pasta.
+    Require that a team has a certain level of access to a repository.
+
+    To use this class as a check, create a subclass that specifies a particular
+    team and permission level, such as RequireTriageTeamAccess below.
     """
 
     def __init__(self, api: GhApi, org: str, repo: str, team: str, permission: str):
@@ -149,8 +151,8 @@ class RequireTeamPermission(Check):
 
 class RequireTriageTeamAccess(RequireTeamPermission):
     """
-    The CC Triage Team needs to be able to triage
-    tickets in all repos in the Open edX Platform.
+    The Core Contributor Triage Team needs to be able to triage
+    issues in all repos in the Open edX Platform.
 
     The check function will tell us if the team has the correct level of access
     and the fix function will make it so if it does not.

--- a/migrate/repo_checks.py
+++ b/migrate/repo_checks.py
@@ -79,12 +79,16 @@ class RequireTeamPermission(Check):
     """
     A generic check that is not meant to be used directly
     but is used to reduce some copy-pasta.
-
-    Do not use directly, instead, subclass this class with
-    a specific team and permission level.
     """
 
-    def __init__(self, api, org, repo, team, permission):
+    def __init__(self, api: GhApi, org: str, repo: str, team: str, permission: str):
+        """
+        Valid permission strings are defined in the Github REST API docs:
+
+        https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions
+
+        They include 'pull', 'triage', 'push', 'maintain', and 'admin'.
+        """
         super().__init__(api, org, repo)
         self.team = team
         self.permission = permission


### PR DESCRIPTION
- feat: Add a new generic check for a team.
- feat: Add an `is_relevant` interface.
- feat: Use the RequireTeamPermission check in the CLA Check.
- feat: Add a CC Triage Team Check.

Note for reviewers: This one will probably be easier to review commit by commit.
