### PR TITLE
feat: Be clear when it's a dry-run.

### DIFF
--- a/migrate/repo_checks.py
+++ b/migrate/repo_checks.py
@@ -443,6 +443,8 @@ def main(org, dry_run, github_token):
             paged(api.repos.list_for_org, org, per_page=100)
         )
     ]
+    if dry_run:
+        click.secho("DRY RUN MODE: No Actual Changes Being Made", fg="yellow")
 
     for repo in repos:
         click.secho(f"{repo}: ")


### PR DESCRIPTION
Since all the log messages are the same in dry-run as an actual run, be
clear at the top that we're not making any changes.
