### PR TITLE
Technical prereqs for big org-wide label sync

### DIFF
--- a/labels.yml
+++ b/labels.yml
@@ -1,0 +1,17 @@
+# Repository labels to be synced across the entire org.
+# For picking hex colors, you can use: https://www.htmlcolor-picker.com/
+
+- name: ":hammer_and_wrench: maintenance"
+  color: "169509"  # grassy green
+
+- name: "waiting on author"
+  color: "bfd6f6"  # baby blue
+
+- name: "closed-inactivity"
+  color: "dbcd00"  # gold
+
+- name: "needs test run"
+  color: "f5424b"  # crimson red
+
+- name: "good first issue :tada:"
+  color: "43dd35"  # lime green

--- a/labels.yml
+++ b/labels.yml
@@ -3,15 +3,20 @@
 
 - name: ":hammer_and_wrench: maintenance"
   color: "169509"  # grassy green
+  description: !!null
 
 - name: "waiting on author"
   color: "bfd6f6"  # baby blue
+  description: "The PR or issue is waiting on a response from the author"
 
 - name: "closed-inactivity"
   color: "dbcd00"  # gold
+  description: "Indicates a PR has been closed because the author has been inactive for a long period of time."
 
 - name: "needs test run"
   color: "f5424b"  # crimson red
+  description: !!null
 
 - name: "good first issue :tada:"
   color: "43dd35"  # lime green
+  description: !!null

--- a/migrate/repo_checks.py
+++ b/migrate/repo_checks.py
@@ -928,10 +928,12 @@ CHECKS_BY_NAME_LOWER = {check_cls.__name__.lower(): check_cls for check_cls in C
     help=f"Limit to specific check(s), case-insensitive."
 )
 @click.option(
-    "--target",
-    "-t",
+    "--repo",
+    "-r",
+    "repos",
+    default=None,
     multiple=True,
-    help="Repos to run checks in.",
+    help="Limit to specific repo(s).",
 )
 @click.option(
     "--start-at",
@@ -939,11 +941,9 @@ CHECKS_BY_NAME_LOWER = {check_cls.__name__.lower(): check_cls for check_cls in C
     default=None,
     help="Which repo in the list to start running checks at.",
 )
-def main(org, dry_run, github_token, check_names, target, start_at):
+def main(org, dry_run, github_token, check_names, repos, start_at):
     api = GhApi()
-    if target:
-        repos = target
-    else:
+    if not repos:
         repos = [
             repo.name
             for repo in chain.from_iterable(

--- a/migrate/repo_checks.py
+++ b/migrate/repo_checks.py
@@ -415,6 +415,7 @@ class EnsureLabels(Check):
     # Each item should be a dict with the fields:
     #  name: str
     #  color: str (rrggbb hex string)
+    #  description: str
     labels: list
 
     with open(LABELS_YAML_PATH) as labels_yaml:
@@ -441,6 +442,7 @@ class EnsureLabels(Check):
             self._simplify_label(label.name): {
                 "color": label.color,
                 "name": label.name,
+                "description": label.description,
             }
             for label in existing_labels_from_api
         }
@@ -498,6 +500,7 @@ class EnsureLabels(Check):
                         self.repo_name,
                         name=current_label["name"],
                         color=new_label["color"],
+                        description=new_label["description"],
                         new_name=new_label["name"],
                     )
                 except HTTP4xxClientError as e:

--- a/migrate/repo_checks.py
+++ b/migrate/repo_checks.py
@@ -62,7 +62,7 @@ def is_empty(api, org, repo):
             f"heads/{default_branch}",
         )
     except HTTP409ConflictError as e:
-        if "Git Repository is empty." in e.fp.read().decode():
+        if "Git Repository is empty." in str(e):
             return True
         raise
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ cache_to_disk
 click
 ghapi
 pygithub>=1.55
+pyyaml
 requests>=2.26


### PR DESCRIPTION
**This is just a technical implementation PR. The list of labels here is not the full list. To see the full list of labels we plan to add, please see: https://github.com/openedx/terraform-github/pull/61**

## Background

This implements [1. Proposal: Store labels in one central place](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3695214629/openedx+org-wide+labels#1.-Proposal:-Store-labels-in-one-central-place), following the *"Store the labels in a new ~labels.json~ labels.yml file in the same directory as repo_checks.py"* option.

It also spruces up repo_checks a bit in order to run the check which creates/updates the labels. Notably, we introduce the `--check` option, and rename `--target` to `--repo`.
 
Next up after this PR would be:
* Turn off the OSPR label-management feature.
* Remove the DEPR automation step that adds the DEPR label.
* Remove the default new repo labels from org-wide settings.
* update labels.yml based on [2. Proposal: List of starter labels](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3695214629/openedx+org-wide+labels#1.-Proposal:-Store-labels-in-one-central-place). This will be done in #61 .

## Description

Changes are broken up by commit. See the commit log.

## Testing & Applying

I did a dry run of this using: `python -m migrate.repo_checks -c ensurelabels`.

The beginning of the output, with colors:

![image](https://github.com/openedx/terraform-github/assets/3628148/420c5348-195d-4fd5-a8ed-95aca8b4ff10)

Full output: https://gist.github.com/kdmccormick/708fc262ac751ca4728a4d7bc208e93b

Only a handful of repos (the very newest ones) would have labels created by this. Some repos will have label descriptions updated. The majority of repos will have no changes.
