### PR TITLE
feat: add a bunch of organization-wide labels

### DIFF
--- a/labels.yml
+++ b/labels.yml
@@ -12,7 +12,7 @@
 #   is no matching label, the label will be created anew. "Matching" is determined
 #   by comparing the label's lowercased name, with all puncutation, emoji, and special
 #   chars removed.
-# * For picking hex colors, you might use: https://www.htmlcolor-picker.com/
+# * For picking hex colors, you might use: https://www.color-hex.com/
 #   Describe your color with a comment so it's easier to review.
 
 
@@ -32,11 +32,19 @@
 
 - name: "maintenance"
   color: "ff9125"  # construction orange
-  description: "Relates to platform health and/or routine upkeep"
+  description: "Routine upkeep necessary for the health of the platform"
+
+- name: "code health"
+  color: "f0d165"  # caution yellow
+  description: "Proactive technical investment via refactorings, removals, etc."
 
 - name: "security"
-  color: "f0d165"  # caution yellow
+  color: "000000"  # black
   description: "Relates to improving to the security posture of the platform"
+
+- name: "a11y"
+  color: "ffffff"  # white
+  description: "Relates to platform accessibility"
 
 - name: "enhancement"
   color: "a2eeef"  # electric blue!
@@ -45,6 +53,7 @@
 - name: "documentation"
   color: "0052cc"  # royal blue
   description: "Relates to documentation improvements"
+
 
 
 ### LABELS INDICATING THE SCOPE OR FUNCTION OF THE ISSUE.
@@ -84,35 +93,68 @@
 
 ### LABELS USED IN THE OPEN EDX CONTRIBUTION WORKFLOW.
 ### PLEASE CONSULT WITH OPEN EDX PROJECT MANAGMENT BEFORE CHANGING THESE.
+### YOU CAN SEE THE CURRENT PROJECT MANAGERS HERE:
+### https://openedx.atlassian.net/wiki/spaces/COMM/pages/3548807177/Community+Contributions+Project+Manager#Current-OSPR-Project-Managers
 
+# Waiting for the author to respond to change requests, feedback, failing
+# tests, etc. Usually this label is used for PRs in board statuses other
+# than “Waiting for Author” (e.g. the pull request is “In Eng Review”
+# column on the board, but the author needs to address review feedback).
 - name: "waiting on author"
   color: "bfd6f6"  # baby blue
-  description: "PR reviewers are waiting on the author to answer questions, fix tests, etc."
+  description: "PR author needs to resolve review requests, answer questions, fix tests, etc."
 
+# Used when the author has been unresponsive for several months.
+# Typically author will be told “we might need to close this due to
+# inactivity” and if there’s still no response we close it a couple weeks later.
 - name: "inactive"
   color: "cc950a"  # clay-ish brown
   description: "PR author has been unresponsive for several months"
 
+# Closed due to PR being abandoned. Typically used after a PR has been abandoned
+ # and labeled as “inactive.”
 - name: "closed inactivity"
   color: "dbcd00"  # gold
   description: "PR was closed because the author abandoned it"
 
+# This means an author has not contributed to a particular repo before and needs
+# authorization to be able to run tests on the PR. As of May 2023, test authorization
+# is handled manually by Axim.
 - name: "needs test run"
   color: "f5424b"  # crimson red
-  description: "Author's first PR to a repository, awaiting test authorization from Axim"
+  description: "Author's first PR to this repository, awaiting test authorization from Axim"
 
-- name: "open source contribution"
+# Automatically added by bot to PRs coming from community contributors
+# other than (a) Axim itself or (b) those under 2U's entity CLA.
+- name: "open-source-contribution"
   color: "f0f0f0"  # light grey
   description: "PR author is not from Axim or 2U"
 
+ # Indicates that a PR is blocked.
+ # It should say in the PR why the work is blocked (e.g. waiting to merge a related PR first).
 - name: "blocked by other work"
   color: "ffa500"  # yellow orange
   description: "PR cannot be finished until other work is complete"
 
+# Open edX product managers will add this label to PRs which require
+# product review.
 - name: "product review"
   color: "c97bf7"  # light puple
   description: "PR requires product review before merging"
 
+# As of May 2023, 2U has a "blended" development structure through which they design, fund &
+# review contributions from other community providers. Their own tools or project managers
+# may add this label in order to manage such contributions.
+- name: "blended"
+  color: "6b360f" # brown
+  description: "PR is managed through 2U's blended developmnt program"
+
+# This label is a manually applied by PR authors or others to indicate that the
+# author is a Core Contributor, which helps set expectations for reviewers and
+# the project managers. Note that Core Contributors have varying levels of
+# access to each repository, and thus still may need someone else to merge
+# their pull request.
 - name: "core contributor"
-  color: "000000"  # black
-  description: "PR is Core Contributor with rights in this repository (manually added)"
+  color: "ffd700"  # gold!
+  description: "PR author is a Core Contributor (who may or may not have write access to this repo)."
+

--- a/labels.yml
+++ b/labels.yml
@@ -1,22 +1,118 @@
 # Repository labels to be synced across the entire org.
-# For picking hex colors, you can use: https://www.htmlcolor-picker.com/
+# Every item must have a name, color, and description.
 
-- name: ":hammer_and_wrench: maintenance"
-  color: "169509"  # grassy green
-  description: !!null
+# Notes:
+# * Repositories may define their own labels as long as they don't
+#   conflict with what's listed here. If it turns out a repository-specific
+#   label would be useful to have in the entire organization, we can always add
+#   it here post facto.
+# * We have added these based on need. They are not all-encompassing. If something
+#   seems missing, feel free to open a PR.
+# * Whenever a repo has a matching label, that label will be updated. If there
+#   is no matching label, the label will be created anew. "Matching" is determined
+#   by comparing the label's lowercased name, with all puncutation, emoji, and special
+#   chars removed.
+# * For picking hex colors, you might use: https://www.htmlcolor-picker.com/
+#   Describe your color with a comment so it's easier to review.
+
+
+### LABELS INDICATING HOW ISSUES CAN BE ENAGAGED WITH.
+
+- name: "good first issue"
+  color: "42dd35"  # friendly lime green
+  description: "A good task for a newcomer to start with"
+
+- name: "help wanted"
+  color: "54976d"  # fenway green
+  description: "Ready to be picked up by anyone in the community"
+
+
+### LABELS INDICATING BROAD THEMES OF WORK.
+### MORE THAN ONE OF THESE MAY APPLY AT A TIME.
+
+- name: "maintenance"
+  color: "ff9125"  # construction orange
+  description: "Relates to platform health and/or routine upkeep"
+
+- name: "security"
+  color: "f0d165"  # caution yellow
+  description: "Relates to improving to the security posture of the platform"
+
+- name: "enhancement"
+  color: "a2eeef"  # electric blue!
+  description: "Relates to new features or improvements to existing features"
+
+- name: "documentation"
+  color: "0052cc"  # royal blue
+  description: "Relates to documentation improvements"
+
+
+### LABELS INDICATING THE SCOPE OR FUNCTION OF THE ISSUE.
+### AT MOST ONE OF THESE SHOULD BE USED AT A TIME.
+
+- name: "depr"
+  color: "3c3cc3"  # indigo-blue
+  description: "Proposal for deprecation & removal per OEP-21"
+
+- name: "bug"
+  color: "d93f0b"  # scarlet red...
+  description: "Report of or fix for something that isn't working as intended"
+
+- name: "discovery"
+  color: "d876e3"  # a curious shade of lavendar
+  description: "Pre-work to determine if an idea is feasible"
+
+- name: "epic"
+  color: "7e027e"  # epic violet
+  description: "Large unit of work, consisting of multiple tasks"
+
+- name: "initiative"
+  color: "340963"  # formidably deep mauve
+  description: "Huge unit of work, consisting of multiple epics"
+
+
+### LABELS INDICATING ISSUE OUTCOMES.
+
+- name: "wontfix"
+  color: "ffffff"  # white
+  description: "This will not be worked on"
+
+- name: "duplicate"
+  color: "cfd3d7"  # duplicitous grey
+  description: "This issue or pull request already exists elsewhere"
+
+
+### LABELS USED IN THE OPEN EDX CONTRIBUTION WORKFLOW.
+### PLEASE CONSULT WITH OPEN EDX PROJECT MANAGMENT BEFORE CHANGING THESE.
 
 - name: "waiting on author"
   color: "bfd6f6"  # baby blue
-  description: "The PR or issue is waiting on a response from the author"
+  description: "PR reviewers are waiting on the author to answer questions, fix tests, etc."
 
-- name: "closed-inactivity"
+- name: "inactive"
+  color: "cc950a"  # clay-ish brown
+  description: "PR author has been unresponsive for several months"
+
+- name: "closed inactivity"
   color: "dbcd00"  # gold
-  description: "Indicates a PR has been closed because the author has been inactive for a long period of time."
+  description: "PR was closed because the author abandoned it"
 
 - name: "needs test run"
   color: "f5424b"  # crimson red
-  description: !!null
+  description: "Author's first PR to a repository, awaiting test authorization from Axim"
 
-- name: "good first issue :tada:"
-  color: "43dd35"  # lime green
-  description: !!null
+- name: "open source contribution"
+  color: "f0f0f0"  # light grey
+  description: "PR author is not from Axim or 2U"
+
+- name: "blocked by other work"
+  color: "ffa500"  # yellow orange
+  description: "PR cannot be finished until other work is complete"
+
+- name: "product review"
+  color: "c97bf7"  # light puple
+  description: "PR requires product review before merging"
+
+- name: "core contributor"
+  color: "000000"  # black
+  description: "PR is Core Contributor with rights in this repository (manually added)"


### PR DESCRIPTION
## Description

This populates labels.yml with a list of labels that will be synced across the openedx GitHub organization. The labels will be synced by Axim using repo_checks.py.

The labels' spelling, color, and description will be made consistent. If a repo has an existing label with similar spelling (that is: ignoring capitalization, emoji, spaces, and special characters) then the label will be edited in-place instead of created anew. So, we shouldn't have a bunch of old-spelling labels lying around when this is done.

The proposed labels.yml is based on the [comments on this wiki page](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3695214629/openedx+org-wide+labels#2.-Proposal%3A-List-of-starter-labels).

## Considerations

### Blocking work

This PR is based on the work from https://github.com/openedx/terraform-github/pull/60, which actually implements the labels.yml syncing. If you want to review the _implementation_ rather than the _labels_, refer to that PR.

Also, before applying these labels to the org, we need to ensure that:
* the OSPR bot is no longer managing these labels in openedx repos.
* the DEPR workflow is no longer trying to add the `DEPR` label to repos.

### Followup work

Once `core contributor` is added to every repo, we can wrap up: https://github.com/openedx/openedx-webhooks/issues/227

### No emoji

I decided not to include emoji in the labels. My driving motivation is that searches/filters become harder to type and harder to read when emoji are involved. Consider:

```
org:openedx is:open label:epic,initiative,discovery 
```

versus

```
org:openedx is:open label:":dizzy: epic",":100: initiative",":mag_right: discovery"
```

I could be persuaded otherwise; what's most important to me is that we're consistent :)

### Things to keep in mind...

* This is a first pass. We can edit these new labels later. We don't have the machinery to _delete_ labels yet, but we could certainly add that later too if necessary. _Anything is better than what we have now._
* We don't know exactly how these labels should be used, and even if we did, we don't have time to police the community to make sure they're used "correctly". So, rather than trying to design a single perfect workflow, I've tried to provide a set of generally useful set of labels that we can experiment with.
* Any proposed changes to the CONTRIBUTION WORKFLOW labels should involve @mphilbrick211 and @itsjeyd , as they are the ones that run that process.

